### PR TITLE
Corrige sobrescrita de campos no método updateOrdemServico

### DIFF
--- a/src/services/ordemServicoService.ts
+++ b/src/services/ordemServicoService.ts
@@ -208,13 +208,13 @@ export default class OrdemServicoService {
             }
         }
         
-        // [AGORA] Usando Constructor Pattern para mapear dados parciais
-        Object.assign(ordemServico, new OrdemServico(data));
-        
-        /* [ANTES] Atribuindo diretamente sem constructor
-        Object.assign(ordemServico, data);
-        */
-        
+        // Merge seletivo: apenas campos do payload (evita sobrescrever com undefined)
+        Object.keys(data).forEach(key => {
+            if ((data as any)[key] !== undefined) {
+                (ordemServico as any)[key] = (data as any)[key];
+            }
+        });
+
         return await this.ordemServicoRepository.save(ordemServico);
     }
 


### PR DESCRIPTION
### Problema

O método `updateOrdemServico` utilizava `Object.assign(ordemServico, new OrdemServico(data))`, que criava um novo objeto de entidade apenas com os campos presentes no payload. Isso fazia com que todos os campos não enviados (como `idTecnico`, `idSolicitante`, `aberturaEm`, etc.) fossem sobrescritos com `undefined`, causando violação de constraint `NOT NULL` no banco ao tentar salvar.

**Erro retornado:**
QueryFailedError: null value in column "id_usuario_tecnico" of relation "ordem_servico" violates not-null constraint



### Causa Raiz

O constructor pattern `new OrdemServico(data)` mapeia apenas os campos recebidos, deixando os demais como `undefined`. Ao usar `Object.assign`, esses `undefined` sobrescreviam os valores originais da entidade carregada do banco.

### Solução

Substituído `Object.assign(ordemServico, new OrdemServico(data))` por um merge seletivo que itera apenas os campos presentes no payload e ignora valores `undefined`:

```typescript
// Antes 
Object.assign(ordemServico, new OrdemServico(data));

// Depois 
Object.keys(data).forEach(key => {
    if ((data as any)[key] !== undefined) {
        (ordemServico as any)[key] = (data as any)[key];
    }
});
```

### Impacto
PUT /app/ordens/:id e PUT /app/os/:id passam a retornar 200 OK
Campos não enviados no body são preservados com seus valores originais
Nenhum impacto nos métodos createOrdemServico e patchOrdemServico

### Arquivo Alterado
 ordemServicoService.ts  — método: updateOrdemServico